### PR TITLE
Use chromium for image, fixes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Chrome Headless
+
+## To run (without seccomp):
+`docker run -d -p 9222:9222 --cap-add=SYS_ADMIN isholgueras/chrome-headless`
+ 
+## To run a better way (with seccomp):
+`docker run -d -p 9222:9222 --security-opt seccomp=$HOME/chrome.json isholgueras/chrome-headless`
+
+## Using In DevTools
+Open Chrome and browse to `http://localhost:9222/`.
+
+## Information on Chrome headless
+
+* [Getting Started with Chrome Headless](https://developers.google.com/web/updates/2017/04/headless-chrome)
+* [Chromium tracker](https://bugs.chromium.org/p/chromium/issues/list?q=label:Proj-Headless)
+* [Headless Chromium README](https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md)
+* [headless-dev mailing list](https://groups.google.com/a/chromium.org/forum/#!forum/headless-dev)
+
+## General Use
+`docker run -d -p 9222:9222 isholgueras/chrome-headless`
+
+## Using In DevTools
+Open Chrome and browse to `http://localhost:9222/`.
+
+#Known issues
+
+## Unsafe Scripts
+You may have to _Load unsafe scripts_ from the omnibox shield icon to allow connecting to the insecure websocket endpoint `ws://localhost:9222`:
+
+![image](https://cloud.githubusercontent.com/assets/39191/21593324/b3e92618-d0ca-11e6-9472-d07b9b9df2c9.png)
+
+## Red herrings
+Depending on the current build, if you run the container interactively you may see things like this on the console:
+```sh
+[0501/162901.033074:WARNING:audio_manager.cc(295)] Multiple instances of AudioManager detected
+[0501/162901.033169:WARNING:audio_manager.cc(254)] Multiple instances of AudioManager detected
+```
+In most cases, these messages can be safely ignored. They will sometimes change and eventually as things are updated in the source tree, resolved.
+
+## Building and Pushing
+
+To build, `./build.sh <tag>`, for example ./build.sh justinbeiro/chrome-headless:20211007-chromium
+
+To push, `./build.sh <tag>`, for example `./push.sh justinbeiro/chrome-headless:20211007-chromium`. This will push both amd64 and arm64 images.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ $# != 1 ]; then
+  echo "\$1 must be the tag, like isholgueras/chrome-headless:20211007-chromium" && exit 1
+fi
+tag=$1
+
+# Build only the current architecture
+docker buildx build -o type=docker -t ${tag} .

--- a/push.sh
+++ b/push.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ $# != 1 ]; then
+  echo "\$1 must be the push-to image, like isholgueras/chrome-headless:20211007-chromium" && exit 1
+fi
+pushto=$1
+
+# build and push both arm64 and amd64 architectures
+docker buildx build --push --platform=linux/arm64,linux/amd64 -t ${pushto} .


### PR DESCRIPTION
This fixes #1 by changing the image to a more current version of debian, with the chromium package (which comes in arm64) instead of the chrome packages, which do not.

This also adds some convenience packages. It seems to work fine with the headless-chrome recipe in ddev-contrib. 

This is pushed to randyfay/chrome-headless:chromium-isholgueras for experimentation (and has both amd64 and arm64)

Note that I created a PR for the former upstream, https://github.com/justinribeiro/dockerfiles/pull/60, but I didn't want to wait for that so brought it all in here. 